### PR TITLE
Option to eval on save

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,11 @@ default) to finish.
 
 (add-hook 'go-mode-hook #'my-go-hook)
 ```
+
+### Options
+
+#### `go-scratch-save-does-eval`
+
+Setting this to a non-nil value will evaluate the buffer with the keybinding `C-x C-s`
+
+You can also `M-x customize` this option

--- a/go-scratch.el
+++ b/go-scratch.el
@@ -40,6 +40,11 @@
   :type 'number
   :group 'go-scratch)
 
+(defcustom go-scratch-save-does-eval nil
+  "\\<go-scratch-mode-map> If non-nil, do an evaluate the scratch buffer with the default save keyboard binding."
+  :type 'boolean
+  :group 'go-scratch)
+
 (defvar go-scratch-buffer-name "*go-scratch*"
   "The buffer name for the Go scratch buffer.")
 
@@ -112,11 +117,19 @@ Program stdout will be printed to the message output."
             (message "%s" (buffer-string))
           (message "Compilation failed: %s" (buffer-string)))))))
 
+(defun go-scratch-save-or-eval ()
+  "Either save or eval the do-scratch buffer depending on the setting of `go-scratch-save-does-eval'."
+  (interactive)
+  (if go-scratch-save-does-eval
+      (go-scratch-eval-buffer)
+    (save-buffer)))
+
 (defvar go-scratch-mode-map
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map go-mode-map)
     (define-key map (kbd "C-c C-c") #'go-scratch-eval-buffer)
     (define-key map (kbd "C-c C-p") #'go-play-buffer)
+    (define-key map (kbd "C-x C-s") #'go-scratch-save-or-eval)
     map))
 
 (define-derived-mode go-scratch-mode go-mode "Go scratch interaction"


### PR DESCRIPTION
Setting `go-scratch-eval-does-save` to non-nil will make `C-x C-s` perform `go-scratch-eval-buffer` instead of `save-buffer`. Default is the current behavior.